### PR TITLE
cfm_143 Change verified field data type, make fridge id less restrictive

### DIFF
--- a/CommunityFridgeMapApi/dependencies/python/db.py
+++ b/CommunityFridgeMapApi/dependencies/python/db.py
@@ -347,9 +347,7 @@ class Fridge(DB_Item):
         if fridge is not None:
             fridge = DB_Item.process_fields(fridge)
             self.id: str = fridge.get("id", None)
-            self.name: str = fridge.get(
-                "name", None
-            )  # name must be alphanumeric and can contain spaces
+            self.name: str = fridge.get("name", None)
             self.tags: list = fridge.get("tags", None)
             self.location: dict = fridge.get("location", None)
             self.maintainer: dict = fridge.get("maintainer", None)
@@ -417,7 +415,7 @@ class Fridge(DB_Item):
 
     def is_valid_name(self) -> bool:
         """
-        Checks if a Fridge name is valid. A valid name is alphanumric and can contain spaces
+        Checks if a Fridge name is valid.
             Returns:
                 bool (bool):
         """

--- a/CommunityFridgeMapApi/dependencies/python/db.py
+++ b/CommunityFridgeMapApi/dependencies/python/db.py
@@ -328,7 +328,7 @@ class Fridge(DB_Item):
             "type": "S",
         },
         "last_edited": {"required": False, "type": "N", "max_length": 20},
-        "verified": {"required": False, "type": "B"},
+        "verified": {"required": False, "type": "BOOL"},
         "latestFridgeReport": {"required": False, "type": "S"},
         "latestFridgeReport/epochTimestamp": {"required": False},
         "latestFridgeReport/timestamp": {"required": False},
@@ -411,8 +411,9 @@ class Fridge(DB_Item):
         """
         Sets the Fridge id. Fridge id is the Fridge name with no spaces and all lower cased
         """
-        id = self.name.lower().replace(" ", "")
-        self.id = id
+        if self.name is not None:
+            id = self.name.lower().replace(" ", "")
+            self.id = id
 
     def is_valid_name(self) -> bool:
         """
@@ -420,8 +421,7 @@ class Fridge(DB_Item):
             Returns:
                 bool (bool):
         """
-        id = self.name.lower().replace(" ", "")
-        return id.isalnum()
+        return re.match(r"^[A-Za-z0-9_#\-‘'. ]+$", self.name) is not None
 
     def validate_fields(self) -> Field_Validator:
         """
@@ -446,8 +446,8 @@ class Fridge(DB_Item):
         """
         if fridgeId is None:
             return False, "Missing Required Field: id"
-        if not fridgeId.isalnum():
-            return False, "id Must Be Alphanumeric"
+        if re.match(r"^[A-Za-z0-9_#\-‘'.]+$", fridgeId) is None:
+            return False, "id has invalid characters"
         id_length = len(fridgeId)
         is_valid_id_length = Fridge.MIN_ID_LENGTH <= id_length <= Fridge.MAX_ID_LENGTH
         if not is_valid_id_length:

--- a/CommunityFridgeMapApi/template.yaml
+++ b/CommunityFridgeMapApi/template.yaml
@@ -63,7 +63,7 @@ Resources:
       CodeUri: functions/fridge_reports
       Handler: app.lambda_handler
       Runtime: python3.9
-      FunctionName: FridgeReportFunction
+      FunctionName: !Sub FridgeReportFunction${Stage}
       Environment:
         Variables:
           Environment: !Ref Environment
@@ -104,6 +104,7 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
+      FunctionName: !Sub HelloWorldFunction${Stage}
       CodeUri: functions/dev/hello_world/
       Handler: app.lambda_handler
       Runtime: python3.9
@@ -125,7 +126,7 @@ Resources:
       CodeUri: functions/fridges/v1
       Handler: app.lambda_handler
       Runtime: python3.9
-      FunctionName: FridgesFunction
+      FunctionName: !Sub FridgesFunction${Stage}
       Environment:
         Variables:
           Environment: !Ref Environment
@@ -183,7 +184,7 @@ Resources:
       CodeUri: functions/image/v1
       Handler: app.lambda_handler
       Runtime: python3.9
-      FunctionName: ImageFunction
+      FunctionName: !Sub ImageFunction${Stage}
       Environment:
         Variables:
           Environment: !Ref Environment
@@ -222,7 +223,7 @@ Resources:
       CodeUri: ./functions/dev/load_fridge_data
       Handler: app.lambda_handler
       Runtime: python3.9
-      FunctionName: LoadFridgeDataFunction
+      FunctionName: !Sub LoadFridgeDataFunction${Stage}
       Environment:
         Variables:
           Environment: !Ref Environment
@@ -248,7 +249,7 @@ Resources:
   CommonLayer:
         Type: AWS::Serverless::LayerVersion
         Properties:
-            LayerName: CommunityFridgeMapApiLayer
+            LayerName: !Sub CommunityFridgeMapApiLayer${Stage}
             Description: Dependencies for CommunityFridgeMapApi project
             ContentUri: dependencies/
             CompatibleRuntimes:

--- a/CommunityFridgeMapApi/tests/unit/test_fridge.py
+++ b/CommunityFridgeMapApi/tests/unit/test_fridge.py
@@ -147,7 +147,7 @@ class FridgeTest(unittest.TestCase):
             "food_restrictions": {"L": [{"S": "meat"}]},
             "photoUrl": {"S": "test"},
             "last_edited": {"N": "2342353"},
-            "verified": {"B": True},
+            "verified": {"BOOL": True},
             "latestFridgeReport": {"S": "{}"},
             "json_data": {"S": json.dumps(fridge)},
         }
@@ -162,8 +162,8 @@ class FridgeTest(unittest.TestCase):
         self.assertEqual(message, "Missing Required Field: id")
         self.assertFalse(is_valid)
 
-        is_valid, message = Fridge.is_valid_id("hi-there")
-        self.assertEqual(message, "id Must Be Alphanumeric")
+        is_valid, message = Fridge.is_valid_id("hi there")
+        self.assertEqual(message, "id has invalid characters")
         self.assertFalse(is_valid)
 
         is_valid, message = Fridge.is_valid_id("hi")
@@ -191,8 +191,8 @@ class FridgeTest(unittest.TestCase):
     def test_validate_fields_success(self):
         fridge = Fridge(
             fridge={
-                "id": "good",
-                "name": "good",
+                "id": "goodAZaz09_#-‘'.",
+                "name": "goodAZaz09_#-‘'. ",
                 "location": {"geoLat": 232342, "geoLng": 2342342},
             },
             db_client=None,

--- a/README.md
+++ b/README.md
@@ -63,7 +63,32 @@ Recommend: https://www.postman.com/
 3. GET Fridges: Go to http://localhost:3000/v1/fridges
 4. Get Fridges Filter By Tag: http://localhost:3000/v1/fridges?tag={TAG}
     * Example: http://localhost:3000/v1/fridges?tag=tag1
-
+5. POST Fridge Example:
+```
+curl --location --request POST 'http://127.0.0.1:3000/v1/fridges' --header 'Content-Type: application/json' --data-raw '{
+    "name": "LES Community Fridge #2",
+    "verified": false,
+    "location": {
+        "name": "testing",
+        "street": "466 Grand Street",
+        "city": "New York",
+        "state": "NY",
+        "zip": "10002",
+        "geoLat": 40.715207,
+        "geoLng": -73.983748
+    },
+    "maintainer": {
+        "name": "name",
+        "organization": "org",
+        "phone": "1234567890",
+        "email": "test@test.com",
+        "instagram": "https://www.instagram.com/les_communityfridge",
+        "website": "https://linktr.ee/lescommunityfridge"
+    },
+    "notes": "notes",
+    "photoUrl": "url.com"
+}'
+```
 ### Fridge Report
 
 #### One Time Use


### PR DESCRIPTION
### Issue
API doesn't work when the verified field is passed down. This is because the data type is "B" instead of "BOOL". "B" is for byte

### Updates
1. Change `verified` field to `BOOL`
2. Allow the following fields in id/name: _#\-‘'.

### Testing
1. Make POST request with the verified field and a name that contains the allowed special characters
Example:
```
curl --location --request POST 'http://127.0.0.1:3000/v1/fridges' --header 'Content-Type: application/json' --data-raw '{
    "name": "LES Community Fridge #2",
    "verified": false,
    "location": {
        "name": "testing",
        "street": "466 Grand Street",
        "city": "New York",
        "state": "NY",
        "zip": "10002",
        "geoLat": 40.715207,
        "geoLng": -73.983748
    },
    "maintainer": {
        "name": "name",
        "organization": "org",
        "phone": "1234567890",
        "email": "test@test.com",
        "instagram": "https://www.instagram.com/les_communityfridge",
        "website": "https://linktr.ee/lescommunityfridge"
    },
    "notes": "notes",
    "photoUrl": "url.com"
}'
```