### PR TITLE
[CFM_166] feat: Update SAM template for CORS preflight request

### DIFF
--- a/CommunityFridgeMapApi/template.yaml
+++ b/CommunityFridgeMapApi/template.yaml
@@ -52,9 +52,9 @@ Resources:
           AllowMethods: "'GET,OPTIONS,PATCH,DELETE,POST,PUT'"
           AllowHeaders: "'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length,
             Content-MD5, Content-Type, Date, X-Api-Version'"
-          AllowOrigin: "'fridgefinder.app'"
+          AllowOrigin: "'*'"
           MaxAge: "'86400'"
-        AllowCredentials: true
+          AllowCredentials: false
         EndpointConfiguration: REGIONAL
         Domain:
           DomainName: !Sub api-${Stage}.communityfridgefinder.com

--- a/CommunityFridgeMapApi/template.yaml
+++ b/CommunityFridgeMapApi/template.yaml
@@ -47,9 +47,14 @@ Resources:
       Type: AWS::Serverless::Api
       Properties:
         StageName: !Ref Stage
-        # Allows www.YOUR_DOMAIN.com to call these APIs
-        # SAM will automatically add AllowMethods with a list of methods for this API
-        Cors: "'www.communityfridgefinder.com'"
+        # CORS preflight settings from https://vercel.com/guides/how-to-enable-cors
+        Cors:
+          AllowMethods: "'GET,OPTIONS,PATCH,DELETE,POST,PUT'"
+          AllowHeaders: "'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length,
+            Content-MD5, Content-Type, Date, X-Api-Version'"
+          AllowOrigin: "'fridgefinder.app'"
+          MaxAge: "'86400'"
+        AllowCredentials: true
         EndpointConfiguration: REGIONAL
         Domain:
           DomainName: !Sub api-${Stage}.communityfridgefinder.com


### PR DESCRIPTION
This branch fixes CORS preflight for stage: dev. The CORS preflight request is returning "access-control-allow-origin: www.communityfridgefinder.com". Here is the code to verify the preflight:
```bash
curl -X OPTIONS https://api-dev.communityfridgefinder.com/v1/contact -siw "\\n%{http_code} %{url_effective}\\n"
```

