### PR TITLE
[CFM_181] allow for more image formats on image upload api

### DIFF
--- a/CommunityFridgeMapApi/dependencies/python/s3_service.py
+++ b/CommunityFridgeMapApi/dependencies/python/s3_service.py
@@ -60,7 +60,7 @@ class S3Service:
             logging.error(e)
             raise S3ServiceException(f"Failed to create a bucket {bucket}")
 
-    def write(self, bucket: str, extension: str, blob: bytes):
+    def write(self, bucket: str, content_type: str, blob: bytes):
         """
         writes a binary file to the storage.
             Parameters:
@@ -70,6 +70,7 @@ class S3Service:
             Returns:
                 The key of the newly created file
         """
+        extension = content_type.split("/")[1]
         key = f"{str(uuid.uuid4())}.{extension}"
         self.idempotent_create_bucket(bucket)
 
@@ -78,6 +79,7 @@ class S3Service:
                 Bucket=bucket,
                 Key=key,
                 Body=blob,
+                ContentType=content_type
             )
         except ClientError as e:
             logging.error(e)

--- a/CommunityFridgeMapApi/functions/image/v1/app.py
+++ b/CommunityFridgeMapApi/functions/image/v1/app.py
@@ -8,35 +8,62 @@ except:
     from dependencies.python.s3_service import S3Service
 
 
-def has_webp_magic_number(blob: bytes) -> bool:
-    """
-    Return True if the binary has valid webp magic numbers.
+def api_response(body, status_code) -> dict:
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+        },
+        "body": (body),
+    } 
 
-    Reference: https://datatracker.ietf.org/doc/html/draft-zern-webp
-    """
-    if len(blob) < 15:
-        return False
-    return (
-        blob[0] == 0x52
-        and blob[1] == 0x49
-        and blob[2] == 0x46
-        and blob[3] == 0x46
-        and blob[8] == 0x57
-        and blob[9] == 0x45
-        and blob[10] == 0x42
-        and blob[11] == 0x50
-        and blob[12] == 0x56
-        and blob[13] == 0x50
-        and blob[14] == 0x38
-    )
-
+def get_s3_bucket_name():
+        STAGE = os.getenv("Stage", None)
+        bucket = "community-fridge-map-images"
+        if STAGE is not None:
+            bucket = f"{bucket}-{STAGE}"
+        return bucket
 
 class ImageHandler:
+
+    def get_image_content_type(image_data: str):
+        """
+        Checks if the given image data represents a valid image and returns its content type.
+
+        :param image_data: The binary data of the image.
+        :return: The content type of the image if it is a valid image format, None otherwise.
+        """
+        signatures = {
+            b'\xff\xd8': 'image/jpeg',
+            b'\x89PNG\r\n\x1a\n': 'image/png',
+            b'GIF87a': 'image/gif',
+            b'GIF89a': 'image/gif',
+            b'II*\x00': 'image/tiff',
+            b'MM\x00*': 'image/tiff',
+            # Add more signatures and content types as needed
+        }
+
+        webp_markers = [b'VP8 ', b'VP8L', b'VP8X']
+
+        for signature, content_type in signatures.items():
+            if image_data.startswith(signature):
+                return content_type
+
+        # Check for WebP format separately, as it requires additional checks
+        for marker in webp_markers:
+            if marker in image_data[:16]:
+                return 'image/webp'
+
+        return None
+
     @staticmethod
     def get_binary_body_from_event(event: dict) -> bytes:
         """Extract binary data from request body"""
-        assert event["isBase64Encoded"]
-        return base64.b64decode(event["body"])
+        if event["isBase64Encoded"]:
+            return base64.b64decode(event["body"])
+        else:
+            return None
 
     @staticmethod
     def encode_binary_file_for_response(blob: bytes) -> bytes:
@@ -45,57 +72,31 @@ class ImageHandler:
         https://docs.aws.amazon.com/apigateway/latest/developerguide/lambda-proxy-binary-media.html
         """
         return base64.b64encode(blob)
-
+    
+        
     @staticmethod
     def lambda_handler(event: dict, s3: S3Service) -> dict:
-        STAGE = os.getenv("Stage", None)
+        if event.get("body", None) is None:
+            error_message = {"message": "Received an empty body"}
+            return api_response(body=json.dumps(error_message), status_code=400)
+        if not event.get('isBase64Encoded', False):
+            error_message = {"message": "Must be Base64 Encoded"}
+            return api_response(body=json.dumps(error_message), status_code=400)
 
-        if STAGE is not None:
-            bucket = f"community-fridge-map-images-{STAGE}"
-        else:
-            bucket = "community-fridge-map-images"
-        blob = ImageHandler.get_binary_body_from_event(event)
-        if not has_webp_magic_number(blob):
-            return {
-                "statusCode": 400,
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Access-Control-Allow-Origin": "*",
-                },
-                "body": json.dumps(
-                    {
-                        "message": "Request could not be understood due to incorrect syntax. Image type must be webp."
-                    }
-                ),
-            }
+        bucket = get_s3_bucket_name()
+        image_data = ImageHandler.get_binary_body_from_event(event)
+        content_type = ImageHandler.get_image_content_type(image_data)
+        if content_type is None:
+            error_message = json.dumps({"message": "Invalid Image Format"})
+            return api_response(body=error_message, status_code=400)
         try:
-            key = s3.write(bucket, "webp", blob)
+            key = s3.write(bucket, content_type, image_data)
             url = s3.generate_file_url(bucket, key)
         except:
-            return {
-                "statusCode": 500,
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Access-Control-Allow-Origin": "*",
-                },
-                "body": json.dumps(
-                    {
-                        "message": "Unexpected error prevented server from fulfilling request."
-                    }
-                ),
-            }
-        return {
-            "statusCode": 200,
-            "headers": {
-                "Content-Type": "application/json",
-                "Access-Control-Allow-Origin": "*",
-            },
-            "body": json.dumps(
-                {
-                    "photoUrl": url,
-                }
-            ),
-        }
+            error_message: str = json.dumps({"message": "Unexpected error prevented server from fulfilling request."})
+            return api_response(body={"message": error_message}, status_code=500)
+        body = json.dumps({"photoUrl": url})
+        return api_response(body=body, status_code=200)
 
 
 def lambda_handler(

--- a/CommunityFridgeMapApi/tests/unit/test_image.py
+++ b/CommunityFridgeMapApi/tests/unit/test_image.py
@@ -28,7 +28,7 @@ def test_upload(s3_service_stub: S3ServiceStub):
             )
 
             write_spy.assert_called_once_with(
-                "community-fridge-map-images", "webp", blob
+                "community-fridge-map-images", "image/webp", blob
             )
             generate_file_url_spy.assert_called_once()
             assert_response(
@@ -61,6 +61,6 @@ def test_upload_invalid_binary(s3_service_stub: S3ServiceStub):
             "Access-Control-Allow-Origin": "*",
         },
         body={
-            "message": "Request could not be understood due to incorrect syntax. Image type must be webp."
+            "message": "Invalid Image Format"
         },
     )


### PR DESCRIPTION
### Notes

Allowing the following formats: jpeg, png, gif, tiff, webp

The reasoning for this is that some older Browsers don't support webp

### Testing

#### QA 
1. Start local SAM API `sam local start-api --parameter-overrides ParameterKey=Environment,ParameterValue=local ParameterKey=Stage,ParameterValue=dev --docker-network cfm-network`
2. Upload image (replace `<file-path>` with your actual image path like `"@/home/user/Downloads/sample.jpeg"`)
    ```
    curl --request POST \
      --url http://localhost:3000/v1/photo \
      --header 'Content-Type: image/webp' \
      --data-binary "@<file-path>"
    ```
    
Tested on all accepted files types and unsupported file types

#### Unit Tests
```bash
CFM_BACKEND$ cd CommunityFridgeMapApi
CommunityFridgeMapApi$ pip install -r tests/requirements.txt --user
# unit test
CommunityFridgeMapApi$ python -m pytest tests/unit -v
```

