### PR TITLE
Add Data Model For Subscription Table

### DIFF
--- a/CommunityFridgeMapApi/dependencies/python/subscription.py
+++ b/CommunityFridgeMapApi/dependencies/python/subscription.py
@@ -1,0 +1,72 @@
+import boto3
+import os
+import logging
+import json
+from dataclasses import dataclass
+
+
+from db import DB_Response
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_ddb_connection(
+    env: str = os.getenv("Environment", "")
+) -> "boto3.resource":
+    """Returns a connection to the DynamoDB table"""
+    if env == "local":
+        return boto3.resource(
+            "dynamodb",
+            endpoint_url="http://localhost:4566",
+        )
+    else:
+        return boto3.resource("dynamodb")
+
+
+
+@dataclass
+class Field_Validator:
+    is_valid: str
+    message: str
+
+class Subscription():
+    FIELD_VALIDATION = {
+        "fridgeId": {"required": True, "type": "S"},
+        "statusType": {"required": True, "type": "S"},
+        "notificationLimit": {"required": True, "type": "N"},
+        "listOfUsers": {"required": True, "type": "L"},
+        "users/$/userId": {"required": True, "type": "S"},
+        "users/$/phone": {"required": True, "type": "S"},
+        "users/$/email": {"required": True, "type": "S"},
+        "users/$/lastNotified": {"required": True, "type": "N"},
+    }
+
+    TABLE_NAME = f"subscription_dev"
+
+    def __init__(self, db_client: "boto3.resource('dynamodb')", subscription: dict = None):
+        self.table = db_client.Table(self.TABLE_NAME)
+        if subscription is not None:
+            self.fridgeId = subscription.get("fridgeId", None)
+            self.statusType = subscription.get("statusType", None)
+            self.notificationLimit = subscription.get(
+                "notificationLimit", None)
+            self.listOfUsers = subscription.get("listOfUsers", None)
+
+    
+    def add_item(self) -> DB_Response:
+        """
+        adds item to database
+            Parameters:
+                conditional_expression (str): conditional expression for boto3 function put_item
+
+            Returns:
+                db_response (DB_Response): returns a DB_Response
+        """
+        item = {
+            "fridgeId": self.fridgeId,
+            "statusType": self.statusType,
+            "notificationLimit": self.notificationLimit,
+            "listOfUsers": self.listOfUsers}
+
+        return self.table.put_item(Item=item)

--- a/schema/subscription.json
+++ b/schema/subscription.json
@@ -1,0 +1,27 @@
+{
+  "TableName": "subscription_dev",
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "fridgeId",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "statusType",
+      "AttributeType": "S"
+    }
+  ],
+  "KeySchema": [
+    {
+      "AttributeName": "fridgeId",
+      "KeyType": "HASH"
+    },
+    {
+      "AttributeName": "statusType",
+      "KeyType": "RANGE"
+    }
+  ],
+  "ProvisionedThroughput": {
+    "ReadCapacityUnits": 5,
+    "WriteCapacityUnits": 5
+  }
+}


### PR DESCRIPTION
### Issue
Add data model for Subscription Table. Should contain the following fields:

1. Subscription Model Table
2. fridgeId - partitionKey
3. statusType - range
4. notificationLimit
5. ListofUsers - [{userId, phone, email, lastNotified}] (we will be doing the sorting in the backend)

Requirements:

- [ ]  Create a new file for this data model, maybe “[subscription.py](http://subscription.py/)”
- [ ]  Write a simple add_item() function that adds a “fridgeId” and “statusType” to the db
- [ ]  use boto3 dymanodb instance instead of botocore.client.DynamoDB

[Refer to Trello card for more information.](https://trello.com/c/a7r9SRsF)

### Testing
For testing purposes you can append the following code to the end of subscription.py:

```
ddb_resource = get_ddb_connection("local")
test_subscription = {
    "fridgeId": "greenBrookeFridge",
    "statusType": "example_status_type",
    "notificationLimit": 10,
    "listOfUsers": [{"userId": "example_user_id", "phone": "555-555-5555", "email": "example@example.com", "lastNotified": 2023}],
}

subscription = Subscription(db_client=ddb_resource, subscription=test_subscription)
response = subscription.add_item()
print(response)
```